### PR TITLE
fix(app): stop menu-bar windows flashing-then-closing on first click (macOS)

### DIFF
--- a/apps/screenpipe-app-tauri/src-tauri/src/main.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/main.rs
@@ -1372,6 +1372,13 @@ async fn main() {
             if app_ui_hidden {
                 info!("enterprise: hidden UI mode active, skipping startup app windows");
             } else if !onboarding_store.is_completed {
+                // If the app launched in the background (login item), it isn't
+                // frontmost, so the freshly-created Onboarding window would flash
+                // and get ordered out before the user can interact with it.
+                // Activate first — onboarding legitimately needs the user's
+                // attention. (Same fix as the tray menu items.)
+                #[cfg(target_os = "macos")]
+                crate::window::activate_self_app();
                 let _ = ShowRewindWindow::Onboarding.show(&app.handle());
             } else {
                 let _ = ShowRewindWindow::Home { page: None }.show(&app.handle());

--- a/apps/screenpipe-app-tauri/src-tauri/src/tray.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/tray.rs
@@ -1326,6 +1326,11 @@ fn handle_menu_event(app_handle: &AppHandle, event: tauri::menu::MenuEvent) {
         "open_app" => {
             let app = app_handle.clone();
             let _ = app_handle.run_on_main_thread(move || {
+                // Activate the app first — a tray menu selection doesn't make the
+                // app frontmost, so a freshly-created Home window would otherwise
+                // flash and get ordered out (see activate_self_app docs).
+                #[cfg(target_os = "macos")]
+                crate::window::activate_self_app();
                 let _ = ShowRewindWindow::Home { page: None }.show(&app);
             });
         }
@@ -1333,6 +1338,8 @@ fn handle_menu_event(app_handle: &AppHandle, event: tauri::menu::MenuEvent) {
             let app = app_handle.clone();
             let page = Some("general".to_string());
             let _ = app_handle.run_on_main_thread(move || {
+                #[cfg(target_os = "macos")]
+                crate::window::activate_self_app();
                 let _ = ShowRewindWindow::Home { page }.show(&app);
             });
         }
@@ -1340,6 +1347,8 @@ fn handle_menu_event(app_handle: &AppHandle, event: tauri::menu::MenuEvent) {
             let app = app_handle.clone();
             let page = Some("help".to_string());
             let _ = app_handle.run_on_main_thread(move || {
+                #[cfg(target_os = "macos")]
+                crate::window::activate_self_app();
                 let _ = ShowRewindWindow::Home { page }.show(&app);
             });
         }
@@ -1373,6 +1382,10 @@ fn handle_menu_event(app_handle: &AppHandle, event: tauri::menu::MenuEvent) {
                 let _ = OnboardingStore::update(&app, |onboarding| {
                     onboarding.reset();
                 });
+                // Activate first so the freshly-created Onboarding window comes up
+                // key instead of flashing then closing (see activate_self_app docs).
+                #[cfg(target_os = "macos")]
+                crate::window::activate_self_app();
                 let _ = ShowRewindWindow::Onboarding.show(&app);
             });
         }

--- a/apps/screenpipe-app-tauri/src-tauri/src/window/focus.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/window/focus.rs
@@ -67,6 +67,29 @@ pub fn restore_frontmost_app() {
     });
 }
 
+/// Bring screenpipe itself to the foreground (activate the app).
+///
+/// A macOS status-item (menu-bar) menu does NOT activate its owning app when
+/// the user selects an item. So a window created from a tray menu item is
+/// ordered on screen while the app is still in the background — it never
+/// becomes key and the window-server immediately orders it back out. That is
+/// the "first click flashes then closes, second click opens" bug: the second
+/// click finds the now-existing window and takes the existing-window show path
+/// (which already activates). Calling this BEFORE creating/showing a window
+/// from the tray makes the app frontmost first, so the new window comes up key
+/// and stays. MUST be called on the main thread.
+#[cfg(target_os = "macos")]
+pub fn activate_self_app() {
+    with_autorelease_pool(|| {
+        use objc::{class, msg_send, sel, sel_impl};
+        use tauri_nspanel::cocoa::base::id;
+        unsafe {
+            let ns_app: id = msg_send![class!(NSApplication), sharedApplication];
+            let _: () = msg_send![ns_app, activateIgnoringOtherApps: true];
+        }
+    });
+}
+
 /// Clear the saved frontmost app without re-activating it.
 /// Used when the user intentionally switches Spaces — we don't want to
 /// pull them back by re-activating the previous app.

--- a/apps/screenpipe-app-tauri/src-tauri/src/window/mod.rs
+++ b/apps/screenpipe-app-tauri/src-tauri/src/window/mod.rs
@@ -104,6 +104,8 @@ pub use first_responder::make_nswindow_webview_first_responder;
 #[cfg(target_os = "macos")]
 pub use first_responder::make_webview_first_responder;
 #[cfg(target_os = "macos")]
+pub use focus::activate_self_app;
+#[cfg(target_os = "macos")]
 pub use focus::clear_frontmost_app;
 #[cfg(target_os = "macos")]
 #[allow(unused_imports)]


### PR DESCRIPTION
## What

On macOS, the **first** click on a menu-bar (tray) item that opens a window — **Open screenpipe** (Home), **Settings…**, **Help/feedback**, or **Onboarding** — made the window flash on screen and immediately close. Only the **second** click opened it for real. The same flash happened to the **Onboarding** window when the app launched in the background (login item).

## Why

A macOS status-item (menu-bar) menu does **not** activate its owning app when you pick an item. So when a tray item creates a brand-new window, the window is ordered on screen while the app is still in the background — it never becomes *key*, and the window-server immediately orders it back out. That's the "flash then close."

The second click finds the now-existing (hidden) window and takes the *existing-window* show path, which already calls `activateIgnoringOtherApps` + `makeKeyAndOrderFront` — so it opens correctly. The asymmetry between the **creation** path (no activation) and the **existing-window** path (activates) is the whole bug.

## Fix

Activate the app **before** showing a window from the tray — the smallest, taskbar-scoped change, with no edits to the window-creation code in `window/show.rs`.

- New helper `window::focus::activate_self_app()` — `NSApplication.activateIgnoringOtherApps(true)` on the main thread (macOS only).
- Called at the start of the `open_app`, `settings`, `feedback`, and `onboarding` tray-menu arms, before `ShowRewindWindow::…show()`.
- Also called before the **startup** Onboarding show (`main.rs`) so a background/login-item launch brings onboarding forward instead of flashing it. (Onboarding legitimately needs the user's attention; the established-user Home-on-launch branch is left unchanged so login focus behavior for existing users doesn't change.)

The Timeline overlay (`show` item) is intentionally a **non-activating** NSPanel and is deliberately left untouched.

## Scope / notes

- macOS-only behavior; calls are `#[cfg(target_os = "macos")]`. No Windows/Linux change.
- Does **not** touch the dock-icon (`RunEvent::Reopen`) path — out of scope for this change.

## Testing

- [ ] First click on **Open screenpipe** opens Home immediately (no flash).
- [ ] First click on **Settings…** opens Home immediately.
- [ ] Resetting/opening **Onboarding** from the tray opens immediately.
- [ ] Fresh install / background launch shows onboarding without a flash.
- [ ] Timeline overlay still appears without activating/stealing focus (no Space switch).
