### PR TITLE
fix(meeting-notes): stop gating speaker rename on file path

### DIFF
--- a/apps/screenpipe-app-tauri/components/meeting-notes/replay-strip.tsx
+++ b/apps/screenpipe-app-tauri/components/meeting-notes/replay-strip.tsx
@@ -296,7 +296,13 @@ export function ReplayStrip({ meetingId, segments, timeRange }: ReplayStripProps
   if (sampleSorted.length === 0) return null;
 
   const speakerLabel = activeChunk?.speakerName || (activeChunk?.isInput ? "me" : "speaker");
-  const showSpeakerPopover = !!activeChunk?.audioChunkId && !!activeChunk?.audioFilePath;
+  // Only a real (positive) audio_chunk_id can be reassigned via
+  // /speakers/reassign — audioFilePath is merely for the optional playback
+  // preview inside the popover and can legitimately be empty (e.g. a
+  // background chunk with a corrupted file_path) without blocking renaming.
+  // Live-only rows get a synthetic negative audioChunkId (see
+  // fetchRoutedMeetingTranscript) and must stay excluded.
+  const showSpeakerPopover = (activeChunk?.audioChunkId ?? 0) > 0;
 
   return (
     <section className="border-t border-border pt-5">

--- a/apps/screenpipe-app-tauri/components/meeting-notes/transcript-panel.tsx
+++ b/apps/screenpipe-app-tauri/components/meeting-notes/transcript-panel.tsx
@@ -998,7 +998,11 @@ function SpeakerParagraph({
       style={{ contain: "layout paint" }}
     >
       <div className="flex items-baseline gap-2 mb-1">
-        {block.firstAudioFilePath ? (
+        {/* Gate on chunk id, not file path: reassignment only needs a real
+            audio_chunk_id. firstAudioFilePath can legitimately be empty
+            (e.g. a background chunk with a corrupted file_path) without
+            that blocking renaming — it's only used for playback preview. */}
+        {block.firstAudioChunkId > 0 ? (
           <SpeakerAssignPopover
             audioChunkId={block.firstAudioChunkId}
             speakerId={block.speakerId ?? undefined}

--- a/apps/screenpipe-app-tauri/components/speaker-assign-popover.tsx
+++ b/apps/screenpipe-app-tauri/components/speaker-assign-popover.tsx
@@ -315,24 +315,28 @@ export function SpeakerAssignPopover({
 						</div>
 					)}
 
-					{/* Audio preview toggle */}
-					<div className="pt-2 border-t">
-						<Button
-							variant="ghost"
-							size="sm"
-							className="w-full justify-start text-xs"
-							onClick={() => setShowAudioPreview(!showAudioPreview)}
-						>
-							<Volume2 className="h-3 w-3 mr-2" />
-							{showAudioPreview ? "Hide audio preview" : "Play audio to confirm"}
-						</Button>
+					{/* Audio preview toggle — only offered when we actually have a file
+					    to play; audioFilePath can be empty (e.g. a corrupted
+					    file_path) even though the chunk itself is still assignable. */}
+					{audioFilePath && (
+						<div className="pt-2 border-t">
+							<Button
+								variant="ghost"
+								size="sm"
+								className="w-full justify-start text-xs"
+								onClick={() => setShowAudioPreview(!showAudioPreview)}
+							>
+								<Volume2 className="h-3 w-3 mr-2" />
+								{showAudioPreview ? "Hide audio preview" : "Play audio to confirm"}
+							</Button>
 
-						{showAudioPreview && (
-							<div className="mt-2">
-								<MediaComponent filePath={audioFilePath} />
-							</div>
-						)}
-					</div>
+							{showAudioPreview && (
+								<div className="mt-2">
+									<MediaComponent filePath={audioFilePath} />
+								</div>
+							)}
+						</div>
+					)}
 
 					{/* Mark as noise button */}
 					{speakerId && (


### PR DESCRIPTION
Speaker rename/reassign only needs a real audio_chunk_id, not a valid audioFilePath — file path is only used for the optional audio preview. On Windows, audio_chunks.file_path can come back empty or "." for some chunks, which silently rendered those speaker names as plain, non-interactive text instead of the rename popover — indistinguishable from a real name at a glance. The first rename in a meeting "worked" only because that one chunk happened to have an intact path; every other line was already unclickable.

Gate on firstAudioChunkId/audioChunkId (with the correct >0 check, since live-only rows use a synthetic negative id) instead, and hide the "play audio to confirm" button when there's no file to preview rather than blocking assignment on it.

Fixes #4986

---
name: pull request
about: submit changes to the project
title: "[pr] "
labels: ''
assignees: ''

---

## description

brief description of the changes in this pr.

related issue: #

> attach screenshots / recordings here — **never commit media into the repo.** drag the file into this box (works for anyone, browser only) and github hosts it. on the cli: attach it as a release asset — `gh release upload <tag> file.png` if you can write here, else `gh release create media file.png --repo <you>/screenpipe` on your fork — and paste the url.

## AI assistance and human ownership

read the [AI-assisted contribution policy](https://github.com/screenpipe/screenpipe/blob/main/CONTRIBUTING.md#ai-assisted-contributions).

- AI tool(s) used (`none` if not used):
- autonomy level (`none`, `autocomplete`, `chat`, or `agent`):
- what I personally verified:

- [ ] I personally submitted this PR, understand every material change, and can explain it without asking a model to answer maintainers for me.
- [ ] The problem statement, rationale, and replies to maintainers are my own.

## evidence type

check every category that applies and provide its required evidence below.

- [ ] UI or behavior change — before/after recording
- [ ] Backend change — regression tests and relevant logs/results
- [ ] Performance change — reproducible before/after benchmarks
- [ ] Docs, CI, or pure refactor — relevant checks and an explanation; no video required

## before

for UI or behavior changes, add a recording of the app/CLI before this change. otherwise write `not applicable` and explain why.

## after

for UI or behavior changes, add a recording of the app/CLI after this change. otherwise write `not applicable` and provide the evidence required above.

## how to test

list the exact commands or manual steps you personally ran and their results.

1. 
2. 
3. 

## desktop app checklist (if applicable)

If this PR adds or changes `#[tauri::command]` handlers or Rust types exported to the frontend, from `apps/screenpipe-app-tauri/`:

- [ ] `bun run bindings:generate` (if bindings changed)
- [ ] `bun run bindings:check`
- [ ] `bun run typecheck`

Commands are auto-collected via the vendored `tauri-helper` crate — no manual handler list edits in `main.rs`.
