### PR TITLE
fix(windows-arm64): ship openblas.dll in installer bundle (was only i…

### DIFF
--- a/apps/screenpipe-app-tauri/scripts/setup_openblas.js
+++ b/apps/screenpipe-app-tauri/scripts/setup_openblas.js
@@ -46,6 +46,11 @@ export async function setupOpenBlas({ cwd, winArch }) {
 			) {
 				return false
 			}
+			// ARM64 exe imports the PE internal name "openblas.dll" — the
+			// installer bundles bin/*.dll, so both names must be present.
+			if (winArch === 'arm64' && !(await fs.exists(path.join(directory, 'bin', 'openblas.dll')))) {
+				return false
+			}
 			const configHeader = await fs
 				.readFile(path.join(directory, 'include', 'openblas_config.h'), 'utf8')
 				.catch(() => '')
@@ -87,11 +92,22 @@ async function flattenOpenBlas(openblasPath, winArch) {
 			}
 			await fs.rmdir(includeOpenblas)
 		}
-		// Rename openblas.dll → libopenblas.dll (expected by runtime loader)
+		// The woa64 package ships the DLL as openblas.dll on disk, but its PE
+		// internal name is also "openblas.dll" — the exe's import table resolves
+		// that name at runtime. Build tooling expects libopenblas.dll (matching
+		// x64). Keep BOTH names in bin/ so the installer bundle glob
+		// (tauri.windows.conf.json "openblas\\bin\\*.dll") ships both: renaming
+		// away openblas.dll caused installed ARM64 apps to crash at launch with
+		// "openblas.dll was not found". Copies in whichever direction is missing
+		// so previously-cached extractions (only libopenblas.dll) self-heal.
 		const openblasDll = path.join(openblasPath, 'bin', 'openblas.dll')
 		const libOpenblasDll = path.join(openblasPath, 'bin', 'libopenblas.dll')
-		if (await fs.exists(openblasDll)) {
-			await fs.rename(openblasDll, libOpenblasDll)
+		const hasOpenblasDll = await fs.exists(openblasDll)
+		const hasLibOpenblasDll = await fs.exists(libOpenblasDll)
+		if (hasOpenblasDll && !hasLibOpenblasDll) {
+			await fs.copyFile(openblasDll, libOpenblasDll)
+		} else if (hasLibOpenblasDll && !hasOpenblasDll) {
+			await fs.copyFile(libOpenblasDll, openblasDll)
 		}
 		// Rename openblas.lib → libopenblas.lib (MSVC import library for linking)
 		const openblasLib = path.join(openblasPath, 'lib', 'openblas.lib')


### PR DESCRIPTION
…n dev target dir)

The ARM64 woa64 OpenBLAS DLL's PE export name is openblas.dll, so the installed exe resolves that exact name at runtime. setup_openblas.js renamed it away to libopenblas.dll, and PR #4207 only copied it back into the cargo target dir — fixing 'tauri dev' but not the NSIS bundle, which globs openblas\bin\*.dll. Installed ARM64 apps crashed at launch with 'openblas.dll was not found'.

Keep BOTH names in bin/ (copy instead of rename, healing in either direction so stale cached extractions recover), and require bin/openblas.dll in the arm64 cache validation.

---
name: pull request
about: submit changes to the project
title: "[pr] "
labels: ''
assignees: ''

---

## description

brief description of the changes in this pr.

related issue: #

> attach screenshots / recordings here — **never commit media into the repo.** drag the file into this box (works for anyone, browser only) and github hosts it. on the cli: attach it as a release asset — `gh release upload <tag> file.png` if you can write here, else `gh release create media file.png --repo <you>/screenpipe` on your fork — and paste the url.

## AI assistance and human ownership

read the [AI-assisted contribution policy](https://github.com/screenpipe/screenpipe/blob/main/CONTRIBUTING.md#ai-assisted-contributions).

- AI tool(s) used (`none` if not used):
- autonomy level (`none`, `autocomplete`, `chat`, or `agent`):
- what I personally verified:

- [ ] I personally submitted this PR, understand every material change, and can explain it without asking a model to answer maintainers for me.
- [ ] The problem statement, rationale, and replies to maintainers are my own.

## evidence type

check every category that applies and provide its required evidence below.

- [ ] UI or behavior change — before/after recording
- [ ] Backend change — regression tests and relevant logs/results
- [ ] Performance change — reproducible before/after benchmarks
- [ ] Docs, CI, or pure refactor — relevant checks and an explanation; no video required

## before

for UI or behavior changes, add a recording of the app/CLI before this change. otherwise write `not applicable` and explain why.

## after

for UI or behavior changes, add a recording of the app/CLI after this change. otherwise write `not applicable` and provide the evidence required above.

## how to test

list the exact commands or manual steps you personally ran and their results.

1. 
2. 
3. 

## desktop app checklist (if applicable)

If this PR adds or changes `#[tauri::command]` handlers or Rust types exported to the frontend, from `apps/screenpipe-app-tauri/`:

- [ ] `bun run bindings:generate` (if bindings changed)
- [ ] `bun run bindings:check`
- [ ] `bun run typecheck`

Commands are auto-collected via the vendored `tauri-helper` crate — no manual handler list edits in `main.rs`.
